### PR TITLE
Style fixes to AV1 docs

### DIFF
--- a/AV1.md
+++ b/AV1.md
@@ -1,23 +1,23 @@
-#AV1 codec
+# AV1 codec
 
-##Aomenc installation
-#####Windows installation: 
-https://nwgat.ninja/compile-av1-using-msys2-mingw/
-#####Linux installation:
-https://nwgat.ninja/compiling-aomedia-av1-on-ubuntu/
+## Aomenc installation
+##### Windows installation: 
+<https://nwgat.ninja/compile-av1-using-msys2-mingw/>
+##### Linux installation:
+<https://nwgat.ninja/compiling-aomedia-av1-on-ubuntu/>
 
-https://aomedia.googlesource.com/aom/#building-the-library-and-applications
+<https://aomedia.googlesource.com/aom/#building-the-library-and-applications>
 
-###Aomenc video encoding
+### Aomenc video encoding
 
-#####Windows:
+##### Windows:
 `ffmpeg -i [input] -pix_fmt yuv420p [file].y4m`
 
 `.\aomenc.exe -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m`
 
 `.\aomenc.exe -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m`
 
-#####Linux:
+##### Linux:
 `ffmpeg -i [input] -pix_fmt yuv420p [file].y4m`
 
 `./aomenc -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m`
@@ -25,29 +25,29 @@ https://aomedia.googlesource.com/aom/#building-the-library-and-applications
 `./aomenc -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m`
 
 #### Pipe version:
-#####Linux:
+##### Linux:
 `ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | ./aomenc -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -`
 
 `ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | ./aomenc -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -`
 
-#####Windows:
-######(cmd only, PowerShell loses frames in input data)
+##### Windows:
+###### (cmd only, PowerShell loses frames in input data)
 `ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | .\aomenc.exe -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -`
 
 `ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | .\aomenc.exe -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -`
 
-##Rav1e installation
-https://github.com/xiph/rav1e
+## Rav1e installation
+<https://github.com/xiph/rav1e>
 
-###Rav1e video encoding
-#####Windows:
+### Rav1e video encoding
+##### Windows:
 `ffmpeg -i [input] -pix_fmt yuv420p [file1].y4m`
 
 `.\rav1e.exe [file1].y4m -o [file2].ivf --quantizer 85 --speed 3`
 
 `ffmpeg -i [file2].ivf -c:v copy [output].mkv`
 
-#####Linux:
+##### Linux:
 `ffmpeg -i [input] -pix_fmt yuv420p [file1].y4m`
 
 `./rav1e [file1].y4m -o [file2].ivf --quantizer 85 --speed 3`
@@ -55,26 +55,26 @@ https://github.com/xiph/rav1e
 `ffmpeg -i [file2].ivf -c:v copy [output].mkv`
 
 #### Pipe version:
-#####Linux:
+##### Linux:
 `ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | ./rav1e - -o [output].ivf --quantizer 85 --speed 3`
 
 `ffmpeg -i [output].ivf -c:v copy [output].mkv`
 
-#####Windows:
-######(cmd only, PowerShell has memory leakage problem)
+##### Windows:
+###### (cmd only, PowerShell has memory leakage problem)
 `ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | .\rav1e.exe - -o [output].ivf --quantizer 85 --speed 3`
 
 `ffmpeg -i [output].ivf -c:v copy [output].mkv`
 
-###Video players which supports AV1:
-#####VLC:
-https://www.videolan.org/vlc/ - stable release, works on Linux only
+### Video players which supports AV1:
+##### VLC:
+<https://www.videolan.org/vlc/> - stable release, works on Linux only
 
-https://nightlies.videolan.org/ - unstable builds 
-#####MPC-HC (unofficial)
-https://github.com/clsid2/mpc-hc/releases
-#####MPV
-https://mpv.io/
-#####MPC-BE
-https://sourceforge.net/projects/mpcbe/files/MPC-BE/Release%20builds/
+<https://nightlies.videolan.org/> - unstable builds 
+##### MPC-HC (unofficial)
+<https://github.com/clsid2/mpc-hc/releases>
+##### MPV
+<https://mpv.io/>
+##### MPC-BE
+<https://sourceforge.net/projects/mpcbe/files/MPC-BE/Release%20builds/>
 

--- a/AV1.md
+++ b/AV1.md
@@ -1,80 +1,93 @@
-# AV1 codec
+AV1 codec
+=========
 
-## Aomenc installation
-##### Windows installation: 
+Aomenc
+------
+
+### Installation
+
+#### Windows
 <https://nwgat.ninja/compile-av1-using-msys2-mingw/>
-##### Linux installation:
+
+#### Linux
 <https://nwgat.ninja/compiling-aomedia-av1-on-ubuntu/>
 
 <https://aomedia.googlesource.com/aom/#building-the-library-and-applications>
 
-### Aomenc video encoding
-
-##### Windows:
+### Video encoding
+#### Using intermediate files
+##### Windows
 `ffmpeg -i [input] -pix_fmt yuv420p [file].y4m`
 
 `.\aomenc.exe -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m`
 
 `.\aomenc.exe -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m`
 
-##### Linux:
+##### Linux
 `ffmpeg -i [input] -pix_fmt yuv420p [file].y4m`
 
 `./aomenc -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m`
 
 `./aomenc -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m`
 
-#### Pipe version:
-##### Linux:
+#### Using pipes
+##### Linux
 `ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | ./aomenc -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -`
 
 `ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | ./aomenc -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -`
 
 ##### Windows:
-###### (cmd only, PowerShell loses frames in input data)
+**cmd only, PowerShell loses frames in input data**
+
 `ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | .\aomenc.exe -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -`
 
 `ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | .\aomenc.exe -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -`
 
-## Rav1e installation
+## Rav1e
+
+### Installation
 <https://github.com/xiph/rav1e>
 
-### Rav1e video encoding
-##### Windows:
+### Video encoding
+#### Using intermediate files
+##### Windows
 `ffmpeg -i [input] -pix_fmt yuv420p [file1].y4m`
 
 `.\rav1e.exe [file1].y4m -o [file2].ivf --quantizer 85 --speed 3`
 
 `ffmpeg -i [file2].ivf -c:v copy [output].mkv`
 
-##### Linux:
+##### Linux
 `ffmpeg -i [input] -pix_fmt yuv420p [file1].y4m`
 
 `./rav1e [file1].y4m -o [file2].ivf --quantizer 85 --speed 3`
 
 `ffmpeg -i [file2].ivf -c:v copy [output].mkv`
 
-#### Pipe version:
-##### Linux:
+#### Using pipes
+##### Linux
 `ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | ./rav1e - -o [output].ivf --quantizer 85 --speed 3`
 
 `ffmpeg -i [output].ivf -c:v copy [output].mkv`
 
-##### Windows:
-###### (cmd only, PowerShell has memory leakage problem)
+##### Windows
+**cmd only, PowerShell has memory leakage problem**
+
 `ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | .\rav1e.exe - -o [output].ivf --quantizer 85 --speed 3`
 
 `ffmpeg -i [output].ivf -c:v copy [output].mkv`
 
-### Video players which supports AV1:
-##### VLC:
+## Video players which supports AV1
+### VLC
 <https://www.videolan.org/vlc/> - stable release, works on Linux only
 
 <https://nightlies.videolan.org/> - unstable builds 
-##### MPC-HC (unofficial)
-<https://github.com/clsid2/mpc-hc/releases>
-##### MPV
-<https://mpv.io/>
-##### MPC-BE
-<https://sourceforge.net/projects/mpcbe/files/MPC-BE/Release%20builds/>
 
+### MPC-HC (unofficial)
+<https://github.com/clsid2/mpc-hc/releases>
+
+### MPV
+<https://mpv.io/>
+
+### MPC-BE
+<https://sourceforge.net/projects/mpcbe/files/MPC-BE/Release%20builds/>

--- a/AV1.md
+++ b/AV1.md
@@ -17,31 +17,39 @@ Aomenc
 ### Video encoding
 #### Using intermediate files
 ##### Windows
-`ffmpeg -i [input] -pix_fmt yuv420p [file].y4m`
+```
+ffmpeg -i [input] -pix_fmt yuv420p [file].y4m
 
-`.\aomenc.exe -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m`
+.\aomenc.exe -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m
 
-`.\aomenc.exe -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m`
+.\aomenc.exe -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m
+```
 
 ##### Linux
-`ffmpeg -i [input] -pix_fmt yuv420p [file].y4m`
+```
+ffmpeg -i [input] -pix_fmt yuv420p [file].y4m
 
-`./aomenc -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m`
+./aomenc -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m
 
-`./aomenc -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m`
+./aomenc -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=1500 --fpf=[output].log -o [output].mkv [file].y4m
+```
 
 #### Using pipes
 ##### Linux
-`ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | ./aomenc -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -`
+```
+ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | ./aomenc -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -
 
-`ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | ./aomenc -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -`
+ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | ./aomenc -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -
+```
 
 ##### Windows:
 **cmd only, PowerShell loses frames in input data**
 
-`ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | .\aomenc.exe -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -`
+```
+ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | .\aomenc.exe -p 2 --pass=1 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -
 
-`ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | .\aomenc.exe -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -`
+ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | .\aomenc.exe -p 2 --pass=2 -t 3 --cpu-used=4 --tile-columns=6 --frame-parallel=1 -w 1280 -h 720 --auto-alt-ref=1 --lag-in-frames=25 --profile=0 --end-usage=q --target-bitrate=800 --fpf=[output].log -o [output].mkv -
+```
 
 ## Rav1e
 
@@ -51,31 +59,39 @@ Aomenc
 ### Video encoding
 #### Using intermediate files
 ##### Windows
-`ffmpeg -i [input] -pix_fmt yuv420p [file1].y4m`
+```
+ffmpeg -i [input] -pix_fmt yuv420p [file1].y4m
 
-`.\rav1e.exe [file1].y4m -o [file2].ivf --quantizer 85 --speed 3`
+.\rav1e.exe [file1].y4m -o [file2].ivf --quantizer 85 --speed 3
 
-`ffmpeg -i [file2].ivf -c:v copy [output].mkv`
+ffmpeg -i [file2].ivf -c:v copy [output].mkv
+```
 
 ##### Linux
-`ffmpeg -i [input] -pix_fmt yuv420p [file1].y4m`
+```
+ffmpeg -i [input] -pix_fmt yuv420p [file1].y4m
 
-`./rav1e [file1].y4m -o [file2].ivf --quantizer 85 --speed 3`
+./rav1e [file1].y4m -o [file2].ivf --quantizer 85 --speed 3
 
-`ffmpeg -i [file2].ivf -c:v copy [output].mkv`
+ffmpeg -i [file2].ivf -c:v copy [output].mkv
+```
 
 #### Using pipes
 ##### Linux
-`ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | ./rav1e - -o [output].ivf --quantizer 85 --speed 3`
+```
+ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | ./rav1e - -o [output].ivf --quantizer 85 --speed 3
 
-`ffmpeg -i [output].ivf -c:v copy [output].mkv`
+ffmpeg -i [output].ivf -c:v copy [output].mkv
+```
 
 ##### Windows
 **cmd only, PowerShell has memory leakage problem**
 
-`ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | .\rav1e.exe - -o [output].ivf --quantizer 85 --speed 3`
+```
+ffmpeg -i [input] -pix_fmt yuv420p -f yuv4mpegpipe - | .\rav1e.exe - -o [output].ivf --quantizer 85 --speed 3
 
-`ffmpeg -i [output].ivf -c:v copy [output].mkv`
+ffmpeg -i [output].ivf -c:v copy [output].mkv
+```
 
 ## Video players which supports AV1
 ### VLC


### PR DESCRIPTION
c4ea630 corrects Markdown headlines so they display fine (and makes links unambiguously links)

9799cc5 is pretty drastic, but I think the document looks better this way

6f4eb97 is a minor nitpick that I forgot to include earlier, and should probably be squashed

In fact, maybe all of them should be squashed, but I'll leave that to your judgement